### PR TITLE
fix link to overview page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Tickets are labeled by size, skills required and to indicate workflow. Details c
 To get you started you might want to check out issues concerning [documentation](https://github.com/librariesio/documentation/issues/), [user experience](https://github.com/librariesio/libraries.io/labels/ux), [visual design](https://github.com/librariesio/libraries.io/issues/labels/visual%20design) or perhaps something already [awaiting help](https://github.com/librariesio/libraries.io/labels/help%20wanted). You may find the following useful:
 
 * Our [strategy](/strategy.md) which outlines what our goals are, how we are going to achieve those goals and what we are specifically going to avoid.
-* A [techncial overview](/techoverview.md) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
+* An [overview](/overview) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
 
 ## How Can I Talk To Other Contributors?
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thanks for considering contributing. These guidelines outline how to contribute 
 ## What's Libraries.io About?
 _Our goal is to raise the quality of all software._ 
 
-By outlining our [mission and strategy](/strategy.md) we hope to give you more power to make decisions and determine how best to spend your time. Specifically we tackle three distinct problems:
+By outlining our [mission and strategy](https://docs.libraries.io/strategy) we hope to give you more power to make decisions and determine how best to spend your time. Specifically we tackle three distinct problems:
 
 * Discovery: _Helping developers make faster, more informed decisions about the software that they use._
 * Maintainability: _Helping maintainers understand more about the software they depend upon and the consumers of their software._
@@ -35,7 +35,7 @@ By outlining our [mission and strategy](/strategy.md) we hope to give you more p
 ## What Should I Know Before I Get Started?
 
 ### Code of Conduct
-Libraries.io is an open and inclusive [community of people](https://github.com/orgs/librariesio/people) working together. We expect contributors to abide by our [contributor code of conduct](CODE_OF_CONDUCT.md) which basically say 'be excellent to each other'. Please report unacceptable behavior to conduct@libraries.io
+Libraries.io is an open and inclusive [community of people](https://github.com/orgs/librariesio/people) working together. We expect contributors to abide by our [contributor code of conduct](https://docs.libraries.io/CODE_OF_CONDUCT.md) which basically say 'be excellent to each other'. Please report unacceptable behavior to conduct@libraries.io
 
 ### Langauge
 We communicate predominately in English. Contributions to the project should be made with English as the first language. We are happy for members of the community to communicate in a language other than English in chat, email and video but be aware that this might be considered exclusive by other members of the community. 
@@ -54,7 +54,7 @@ The simplest thing that you can do to help us is by filing good bug reports, so 
 * Double-check that the bug is persistent. The site is still in it's infancy and sometimes artifacts may appear and disappear. 
 * Double-check the bug hasn't already been reported [on our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they *should* be labelled `bug` or `bugsnag`.
 
-If something hasn't been raised, you can go ahead and create a new issue using [the template](/issue_template.md). If you'd like to help investigate further or fix the bug just mention it in your issue and check out our [workflow](#workflow).
+If something hasn't been raised, you can go ahead and create a new issue using [the template](https://docs.libraries.io/issue_template.md). If you'd like to help investigate further or fix the bug just mention it in your issue and check out our [workflow](#workflow).
 
 ### Suggesting Enhancements
 
@@ -64,7 +64,7 @@ The next simplest thing you can do to help us is by telling us how we can improv
 
 * Check that the enhancement is not already [in our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be labelled 'enhancement'.
 
-If there isn't already an issue for feature then go ahead and create a new issue for it using the [template](/issue_template.md). If you'd like to work on the enhancement then just mention it in a comment and check out our [workflow](#workflow).
+If there isn't already an issue for feature then go ahead and create a new issue for it using the [template](https://docs.libraries.io/issue_template.md). If you'd like to work on the enhancement then just mention it in a comment and check out our [workflow](#workflow).
 
 ### Suggesting New Features
 
@@ -72,23 +72,23 @@ If you're into this zone then you need to understand a little more about what we
 
 #### Before Suggesting a Feature
 
-* Check that it aligns with [our strategy](strategy.md) and is specifically not in line with something we have said we will not do (for the moment this is anything to do with ranking *people*).
+* Check that it aligns with [our strategy](https://docs.libraries.io/strategy) and is specifically not in line with something we have said we will not do (for the moment this is anything to do with ranking *people*).
 * Check that the feature is not already [in our issue tracker](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Alibrariesio), they should be tagged 'feature'.
 * Specifically check that it is not already a [funded commitment](https://github.com/librariesio/supporters/issues).
 
-If you're still thinking about that killer feature that no one else is thinking about then *please* create an issue for it using the [template](/issue_template.md).
+If you're still thinking about that killer feature that no one else is thinking about then *please* create an issue for it using the [template](https://docs.libraries.io/issue_template.md).
 
 ### Your First Contribution
 You're in luck! We label issues that are ideal for first time contributors with [`first-pr`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Alibrariesio+label%3A%22first-pr%22). For someone who wants something a little more meaty you might find an issue that needs some assistance with [`help wanted`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Alibrariesio+label%3A%22help+wanted%22). Next you'll want to read our [workflow](#workflow).
 
 ### Tackling Something Meatier
 
-Tickets are labeled by size, skills required and to indicate workflow. Details can be found in our [labelling policy](/labelling.md). 
+Tickets are labeled by size, skills required and to indicate workflow. Details can be found in our [labelling policy](https://docs.libraries.io/labelling). 
 
 To get you started you might want to check out issues concerning [documentation](https://github.com/librariesio/documentation/issues/), [user experience](https://github.com/librariesio/libraries.io/labels/ux), [visual design](https://github.com/librariesio/libraries.io/issues/labels/visual%20design) or perhaps something already [awaiting help](https://github.com/librariesio/libraries.io/labels/help%20wanted). You may find the following useful:
 
-* Our [strategy](/strategy.md) which outlines what our goals are, how we are going to achieve those goals and what we are specifically going to avoid.
-* An [overview](/overview) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
+* Our [strategy](https://docs.libraries.io/strategy) which outlines what our goals are, how we are going to achieve those goals and what we are specifically going to avoid.
+* An [overview](https://docs.libraries.io/overview) of the components that make up the Libraries.io project and run the [https://libraries.io](https://libraries.io) site.
 
 ## How Can I Talk To Other Contributors?
 
@@ -136,10 +136,10 @@ We *try* to use principles of [GitHub-flow](https://lucamezzalira.com/2014/03/10
 We *try* to create an issue for everything. That is any bug, feature or enhancement that is worth an open, focussed and documented discussion. 
 
 #### Labelling 
-We constrain labels as they are a key part of our workflow. Tickets will be labeled according to our [labelling policy](/labelling.md).
+We constrain labels as they are a key part of our workflow. Tickets will be labeled according to our [labelling policy](https://docs.libraries.io/labelling).
 
 #### Templates
-We use templates to guide contributors toward good practice in [filing bugs, requesting enhancements and features](/issue_template.md) and in [issuing pull-requests](/pull_request_template.md).
+We use templates to guide contributors toward good practice in [filing bugs, requesting enhancements and features](https://docs.libraries.io/issue_template.md) and in [issuing pull-requests](https://docs.libraries.io/pull_request_template.md).
 
 #### Commenting
 If it possible to comment your contribution — for instance if you are contributing code — then do so in a way that is simple, clear, concise and lowers the level of understanding necessary for others to comprehend what comes afterward does or achieves. If you are contributing code it is very likely it will be rejected if it does not contain sufficient comments. 
@@ -151,15 +151,16 @@ When committing to a branch be sure to use plain, simple language that describes
 When adding or fixing functionality, tests should be added to help reduce future regressions and breakage. All tests are ran automatically when new commits are pushed to a branch. Pull requests with broken/missing tests are not likely to be merged.
 
 #### Submitting for Review
-Once a piece of work (in a branch) is complete it should be readied for review. This is your last chance to ensure that your contribution is [properly tested](#testing). If you are contributing code it is likely your contribution will be rejected if it would lower the test-coverage. Once this is done you can submit a pull-request following the [template](/pull_request_template.md).
+Once a piece of work (in a branch) is complete it should be readied for review. This is your last chance to ensure that your contribution is [properly tested](#testing). If you are contributing code it is likely your contribution will be rejected if it would lower the test-coverage. Once this is done you can submit a pull-request following the [template](https://docs.libraries.io/pull_request_template.md).
 
 It is likely that your contributions will need to be checked by at least one member of the [core team](https://github.com/orgs/librariesio/teams/core) prior to merging. It is also incredibly likely that your contribution may need some re-work in order to be accepted. Particularly if it lacks an appropriate level of comments, tests or it is difficult to understand your commits. Please do not take offense if this is the case. We understand that contributors give their time because they want to improve the project but please understand it is another's responsibility to ensure that the project is maintainable, and good practices like these are key to ensuring that is possible. 
 
 #### Reviewing a PR
-We appreciate that it may be difficult to offer constructive criticism, but it is a necessary part of ensuring the project is maintainable and successful. If it is difficult to understand something, request it is better commented. If you do not feel assured of the robustness of a contribution, request it is better tested. If it is unclear what the goal of the piece of work is and how it relates to the [strategy](/strategy.md), request a clarification in the corresponding issue. If a pull-request has no corresponding issue, decreases code coverage or otherwise decreases the quality of the project. Reject it. Otherwise, merge it. 
+We appreciate that it may be difficult to offer constructive criticism, but it is a necessary part of ensuring the project is maintainable and successful. If it is difficult to understand something, request it is better commented. If you do not feel assured of the robustness of a contribution, request it is better tested. If it is unclear what the goal of the piece of work is and how it relates to the [strategy](https://docs.libraries.io/strategy), request a clarification in the corresponding issue. If a pull-request has no corresponding issue, decreases code coverage or otherwise decreases the quality of the project. Reject it. Otherwise, merge it. 
 
 #### Merging
-As we keep the `master` branch in a permanent state of 'deployment ready' once-merged your contribution will be live on the next deployment. 
+As we keep the `master` branch in a permanent state of 'deployment ready' once-merged your contribution will be live on the next deployment.
+
 #### Deploying 
 Any member of the [deployers](https://github.com/orgs/librariesio/teams/deployers) team are able to redeploy the site. If you require a deployment then you might find one of them in our `#general` [chat channel on Slack](slack.libraries.io). 
 


### PR DESCRIPTION
As per https://github.com/librariesio/documentation/pull/29 whcih also moves techoverview/md to overview.md